### PR TITLE
Fix Stopwatch comment typo

### DIFF
--- a/src/main/java/org/chaiware/acommander/helpers/Stopwatch.java
+++ b/src/main/java/org/chaiware/acommander/helpers/Stopwatch.java
@@ -1,6 +1,6 @@
 package org.chaiware.acommander.helpers;
 
-/** Simplest Stopwatch, it is created started, and toSting shows the current elapsed time */
+/** Simplest Stopwatch, it is created started, and toString shows the current elapsed time */
 public class Stopwatch {
     private final long startTime;
 


### PR DESCRIPTION
## Summary
- fix typo in Stopwatch class Javadoc

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be38f1af883309bec3436793621e0